### PR TITLE
Modernize: Replace die state strings with a `DieState` enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 + Added type annotations to most everything.
 + Made `Die` a dataclass and started migrating API to use that instead of tuples.
 + Tests were migrated from `unittest` to `pytest`.
++ Migrated the die "state" strings to an enum.
 
 
 ## 0.1.3 / 2017-03-15

--- a/src/gdw/gdw.py
+++ b/src/gdw/gdw.py
@@ -240,7 +240,7 @@ class Die(object):
 
 def max_dist_sqrd(center: Tuple[float, float], size: Tuple[float, float]) -> float:
     """
-    Calculate the squared distnace to the furthest corner of a rectangle.
+    Calculate the squared distance to the furthest corner of a rectangle.
 
     Assumes that the origin is ``(0, 0)``.
 
@@ -294,7 +294,7 @@ def flat_location(dia: float) -> float:
     """
     flat_y = -dia / 2  # assume wafer edge at first
     if dia in FLAT_LENGTHS:
-        # A flat is defined by SEMI M1-0302, so we calcualte where it is
+        # A flat is defined by SEMI M1-0302, so we calculate where it is
         flat_y = -math.sqrt((dia / 2) ** 2 - (FLAT_LENGTHS[dia] * 0.5) ** 2)
 
     return flat_y
@@ -331,7 +331,7 @@ def calc_die_state(
     # Find the die's furthest point
     die_max_sqrd = max_dist_sqrd(coord_die_center, wafer.die_xy)
 
-    # Determine the die's lower-left corner (since that's the orgin for wx).
+    # Determine the die's lower-left corner (since that's the origin for wx).
     coord_lower_left_x = coord_die_center_x - wafer.die_x / 2
     coord_lower_left_y = coord_die_center_y - wafer.die_y / 2
 
@@ -346,7 +346,7 @@ def calc_die_state(
         # it's outside of the exclusion
         status = DieState.EXCLUSION
     elif coord_lower_left_y < (wafer.flat_y + wafer.flat_excl):
-        # it's ouside the flat exclusion
+        # it's outside the flat exclusion
         status = DieState.FLAT_EXCLUSION
     elif north_limit is not None and coord_lower_left_y + wafer.die_y > north_limit:
         status = DieState.SCRIBE
@@ -579,7 +579,7 @@ def gen_mask_file(
     Generate a text file that can be read by the LabVIEW OWT program.
 
     probe_list should only contain die that are fully on the wafer. Die that
-    are within the edxlucion zones but still fully on the wafer *are*
+    are within the exclusion zones but still fully on the wafer *are*
     included.
 
     probe_list is what's returned from maxGDW, so it's a list of

--- a/tests/test_gdw.py
+++ b/tests/test_gdw.py
@@ -67,7 +67,7 @@ def test_Wafer_invalid_center_offset_raises_typeerror(item: Any) -> None:
 
 
 def test_Die_cant_add_attribute() -> None:
-    die = gdw.Die(1, 1, 1, 1, "1")
+    die = gdw.Die(1, 1, 1, 1, gdw.DieState.FLAT)
     with pytest.raises(AttributeError):
         die.new_attribute = 1  # type: ignore[attr-defined]
 
@@ -156,7 +156,7 @@ def test_gdw_known_values(
 ) -> None:
     gdw_list = gdw.gdw(die_xy, diameter, offset_xy, excl, scribe_excl)
     # count only die that are probed
-    got = sum(1 for x in gdw_list[0] if x[4] == "probe")
+    got = sum(1 for x in gdw_list[0] if x[4] == gdw.DieState.PROBE)
     assert got == want
 
 
@@ -169,15 +169,49 @@ def test_die_to_radius_known_values() -> None:
     "wafer, diex, diey, northlim, want",
     [
         # note that the die X and die Y values are unadjusted for starting die!
-        (gdw.Wafer((5, 5), (0, 0), 150, 4.5, 4.5, 70.2), 21, 17, None, "wafer"),
-        (gdw.Wafer((5, 5), (0, 0), 150, 4.5, 4.5, 70.2), 30, 30, None, "probe"),
-        (gdw.Wafer((5, 5), (0, 0), 150, 4.5, 4.5, 70.2), 28, 43, None, "flatExcl"),
-        (gdw.Wafer((5, 5), (0, 0), 150, 4.5, 4.5, 70.2), 31, 44, None, "flat"),
-        (gdw.Wafer((5, 5), (0, 0), 150, 4.5, 4.5, 70.2), 40, 21, None, "excl"),
+        (
+            gdw.Wafer((5, 5), (0, 0), 150, 4.5, 4.5, 70.2),
+            21,
+            17,
+            None,
+            gdw.DieState.WAFER,
+        ),
+        (
+            gdw.Wafer((5, 5), (0, 0), 150, 4.5, 4.5, 70.2),
+            30,
+            30,
+            None,
+            gdw.DieState.PROBE,
+        ),
+        (
+            gdw.Wafer((5, 5), (0, 0), 150, 4.5, 4.5, 70.2),
+            28,
+            43,
+            None,
+            gdw.DieState.FLAT_EXCLUSION,
+        ),
+        (
+            gdw.Wafer((5, 5), (0, 0), 150, 4.5, 4.5, 70.2),
+            31,
+            44,
+            None,
+            gdw.DieState.FLAT,
+        ),
+        (
+            gdw.Wafer((5, 5), (0, 0), 150, 4.5, 4.5, 70.2),
+            40,
+            21,
+            None,
+            gdw.DieState.EXCLUSION,
+        ),
     ],
 )
 def test_calc_die_state_known_values(
-    wafer: gdw.Wafer, diex: int, diey: int, northlim: Optional[float], want: str
+    wafer: gdw.Wafer,
+    diex: int,
+    diey: int,
+    northlim: Optional[float],
+    want: gdw.DieState,
 ) -> None:
     got = gdw.calc_die_state(wafer, diex, diey, northlim)
     assert got[-1] == want


### PR DESCRIPTION
Replace die state strings with a `DieState` enum.

Also fix some minor spelling errors.